### PR TITLE
Update Quarkus, GraalVM and Opeenfaas watchdog. Include application.properties in container 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/template/quarkus-native-slim/Dockerfile
+++ b/template/quarkus-native-slim/Dockerfile
@@ -10,6 +10,11 @@ ADD mvnw /app/
 ADD .mvn /app/.mvn/
 # extra config
 ENV GRAALVM_HOME=$JAVA_HOME
+
+# Cache maven dependency
+ADD function/pom.xml /app/function/pom.xml
+RUN ./mvnw -f /app/function/pom.xml dependency:resolve
+
 # build the function
 ADD function /app/function
 RUN ./mvnw -f /app/function/pom.xml package -Pnative

--- a/template/quarkus-native-slim/Dockerfile
+++ b/template/quarkus-native-slim/Dockerfile
@@ -47,8 +47,6 @@ COPY --from=build-aot /app/function/target/classes/*.properties /config/
 COPY --from=build-aot /app/function/target/*-runner /function
 COPY --from=watchdog /fwatchdog /fwatchdog
 
-
-
 ENV cgi_headers="true"
 ENV fprocess="/function"
 ENV mode="http"

--- a/template/quarkus-native-slim/Dockerfile
+++ b/template/quarkus-native-slim/Dockerfile
@@ -2,7 +2,7 @@
 FROM oracle/graalvm-ce:20.3.0-java11 as build-aot
 RUN gu install native-image
 # Set working dir
-RUN mkdir /app
+RUN mkdir /app && mkdir -p /tmp/tmpapp
 WORKDIR /app
 
 # Add maven wrapper
@@ -12,8 +12,8 @@ ADD .mvn /app/.mvn/
 ENV GRAALVM_HOME=$JAVA_HOME
 
 # Cache maven dependency
-ADD function/pom.xml /app/function/pom.xml
-RUN ./mvnw -f /app/function/pom.xml dependency:resolve
+ADD function/pom.xml /tmp/tmpapp/pom.xml
+RUN ./mvnw -f /tmp/tmpapp/pom.xml dependency:resolve
 
 # build the function
 ADD function /app/function

--- a/template/quarkus-native-slim/Dockerfile
+++ b/template/quarkus-native-slim/Dockerfile
@@ -16,7 +16,7 @@ RUN ./mvnw -f /app/function/pom.xml package -Pnative
 
 
 # use the openfaas image to get the watchdog
-FROM openfaas/of-watchdog:0.7.6 as watchdog
+FROM openfaas/of-watchdog:0.8.1 as watchdog
 
 # Create new image
 FROM registry.access.redhat.com/ubi8/ubi-minimal as base

--- a/template/quarkus-native-slim/Dockerfile
+++ b/template/quarkus-native-slim/Dockerfile
@@ -1,5 +1,5 @@
 # Get a build environment
-FROM oracle/graalvm-ce:19.3.1-java11 as build-aot
+FROM oracle/graalvm-ce:20.3.0-java11 as build-aot
 RUN gu install native-image
 # Set working dir
 RUN mkdir /app
@@ -41,6 +41,9 @@ COPY --from=base "/lib64/libstdc++.so.6" \
 
 FROM base_minimal
 
+RUN mkdir /config
+
+COPY --from=build-aot /app/function/target/classes/*.properties /config/
 COPY --from=build-aot /app/function/target/*-runner /function
 COPY --from=watchdog /fwatchdog /fwatchdog
 

--- a/template/quarkus-native-slim/Dockerfile
+++ b/template/quarkus-native-slim/Dockerfile
@@ -22,10 +22,14 @@ FROM openfaas/of-watchdog:0.8.1 as watchdog
 FROM registry.access.redhat.com/ubi8/ubi-minimal as base
 
 RUN mkdir -p /newtmp && chmod -R 777 /newtmp
+RUN mkdir /configtmp
+
+COPY --from=build-aot /app/function/target/classes/*.properties /configtmp/
 
 FROM scratch as base_minimal
 
 COPY --from=base /newtmp /tmp
+COPY --from=base /configtmp /config
 
 # libraries for quarkus
 COPY --from=base "/lib64/libstdc++.so.6" \
@@ -41,11 +45,11 @@ COPY --from=base "/lib64/libstdc++.so.6" \
 
 FROM base_minimal
 
-RUN mkdir /config
-
 COPY --from=build-aot /app/function/target/classes/*.properties /config/
 COPY --from=build-aot /app/function/target/*-runner /function
 COPY --from=watchdog /fwatchdog /fwatchdog
+
+
 
 ENV cgi_headers="true"
 ENV fprocess="/function"

--- a/template/quarkus-native-slim/function/pom.xml
+++ b/template/quarkus-native-slim/function/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus.version>1.2.0.Final</quarkus.version>
+    <quarkus.version>1.9.2.Final</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /home/app
 
 FROM base
 
-COPY --from=build-aot /app/function/target/classes/*.properties /home/app/config
+COPY --from=build-aot /app/function/target/classes/*.properties /home/app/config/
 COPY --from=build-aot /app/function/target/*-runner /home/app/function
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -34,7 +34,7 @@ FROM base
 
 COPY --from=build-aot /app/function/target/classes/*.properties /home/app/bin/config/
 COPY --from=build-aot /app/function/target/*-runner /home/app/bin/function
-COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /home/app/bin/fwatchdog
 
 ENV cgi_headers="true"
 ENV fprocess="function"

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -25,11 +25,10 @@ FROM openfaas/of-watchdog:0.8.1 as watchdog
 FROM registry.access.redhat.com/ubi8/ubi-minimal as base
 
 RUN microdnf install shadow-utils
-RUN groupadd app && useradd app -g app -d /home/app && mkdir -p /home/app
+RUN groupadd app && useradd app -g app -d /home/app && mkdir -p /home/app/config
 USER app
 
 WORKDIR /home/app
-RUN mkdir -p /home/app/config && chown
 
 FROM base
 

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -23,21 +23,19 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal as base
 
 RUN microdnf install shadow-utils
 RUN groupadd app && useradd app -g app -d /home/app && mkdir -p /home/app
+USER app
 
 WORKDIR /home/app
+RUN mkdir -p /home/app/config && chown
 
 FROM base
 
-RUN mkdir -p /app/config
-
-USER app
-
-COPY --from=build-aot /app/function/target/classes/*.properties /app/config/
-COPY --from=build-aot /app/function/target/*-runner /app/function
+COPY --from=build-aot /app/function/target/classes/*.properties /home/app/config
+COPY --from=build-aot /app/function/target/*-runner /home/app/function
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 
 ENV cgi_headers="true"
-ENV fprocess="/app/function"
+ENV fprocess="/home/app/function"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:8000"
 

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -34,7 +34,7 @@ USER app
 
 COPY --from=build-aot /app/function/target/classes/*.properties /app/config/
 COPY --from=build-aot /app/function/target/*-runner /app/function
-COPY --from=watchdog /fwatchdog /app/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 
 ENV cgi_headers="true"
 ENV fprocess="/app/function"
@@ -48,4 +48,4 @@ ENV read_timeout="25s"
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 
-CMD ["/app/fwatchdog"]
+CMD ["fwatchdog"]

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -10,6 +10,9 @@ ADD mvnw /app/
 ADD .mvn /app/.mvn/
 # extra config
 ENV GRAALVM_HOME=$JAVA_HOME
+# Cache maven dependency
+ADD function/pom.xml /app/function/pom.xml
+RUN ./mvnw -f /app/function/pom.xml dependency:resolve
 # build the function
 ADD function /app/function
 RUN ./mvnw -f /app/function/pom.xml package -Pnative

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -25,16 +25,20 @@ FROM openfaas/of-watchdog:0.8.1 as watchdog
 FROM registry.access.redhat.com/ubi8/ubi-minimal as base
 
 RUN microdnf install shadow-utils
-RUN groupadd app && useradd app -g app -d /home/app && mkdir -p /home/app/bin/config
+RUN groupadd app && useradd app -g app -d /home/app && mkdir -p /home/app/config
 USER app
 
 WORKDIR /home/app
 
 FROM base
 
-COPY --from=build-aot /app/function/target/classes/*.properties /home/app/bin/config/
-COPY --from=build-aot /app/function/target/*-runner /home/app/bin/function
-COPY --from=watchdog /fwatchdog /home/app/bin/fwatchdog
+COPY --from=build-aot /app/function/target/classes/*.properties /home/app/config/
+COPY --from=build-aot /app/function/target/*-runner /home/app/function
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+
+USER root
+RUN ln -s /home/app/function /usr/bin/function
+USER app
 
 ENV cgi_headers="true"
 ENV fprocess="function"

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -1,5 +1,5 @@
 # Get a build environment
-FROM oracle/graalvm-ce:19.3.1-java11 as build-aot
+FROM oracle/graalvm-ce:20.3.0-java11 as build-aot
 RUN gu install native-image
 # Set working dir
 RUN mkdir /app
@@ -25,17 +25,19 @@ RUN microdnf install shadow-utils
 RUN groupadd app && useradd app -g app -d /home/app && mkdir -p /home/app
 
 WORKDIR /home/app
-USER app
 
 FROM base
 
-COPY --from=build-aot /app/function/target/*-runner /usr/bin/function
-COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN mkdir -p /app/config
 
+USER app
 
+COPY --from=build-aot /app/function/target/classes/*.properties /app/config/
+COPY --from=build-aot /app/function/target/*-runner /app/function
+COPY --from=watchdog /fwatchdog /app/fwatchdog
 
 ENV cgi_headers="true"
-ENV fprocess="function"
+ENV fprocess="/app/function"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:8000"
 
@@ -43,6 +45,7 @@ ENV exec_timeout="20s"
 ENV write_timeout="25s"
 ENV read_timeout="25s"
 
+
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 
-CMD ["fwatchdog"]
+CMD ["/app/fwatchdog"]

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -16,7 +16,7 @@ RUN ./mvnw -f /app/function/pom.xml package -Pnative
 
 
 # use the openfaas image to get the watchdog
-FROM openfaas/of-watchdog:0.7.6 as watchdog
+FROM openfaas/of-watchdog:0.8.1 as watchdog
 
 # Create new image
 FROM registry.access.redhat.com/ubi8/ubi-minimal as base

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -2,7 +2,7 @@
 FROM oracle/graalvm-ce:20.3.0-java11 as build-aot
 RUN gu install native-image
 # Set working dir
-RUN mkdir /app
+RUN mkdir /app && mkdir -p /tmp/tmpapp
 WORKDIR /app
 
 # Add maven wrapper
@@ -11,8 +11,8 @@ ADD .mvn /app/.mvn/
 # extra config
 ENV GRAALVM_HOME=$JAVA_HOME
 # Cache maven dependency
-ADD function/pom.xml /app/function/pom.xml
-RUN ./mvnw -f /app/function/pom.xml dependency:resolve
+ADD function/pom.xml /tmp/tmpapp/pom.xml
+RUN ./mvnw -f /tmp/tmpapp/pom.xml dependency:resolve
 # build the function
 ADD function /app/function
 RUN ./mvnw -f /app/function/pom.xml package -Pnative

--- a/template/quarkus-native/Dockerfile
+++ b/template/quarkus-native/Dockerfile
@@ -25,19 +25,19 @@ FROM openfaas/of-watchdog:0.8.1 as watchdog
 FROM registry.access.redhat.com/ubi8/ubi-minimal as base
 
 RUN microdnf install shadow-utils
-RUN groupadd app && useradd app -g app -d /home/app && mkdir -p /home/app/config
+RUN groupadd app && useradd app -g app -d /home/app && mkdir -p /home/app/bin/config
 USER app
 
 WORKDIR /home/app
 
 FROM base
 
-COPY --from=build-aot /app/function/target/classes/*.properties /home/app/config/
-COPY --from=build-aot /app/function/target/*-runner /home/app/function
+COPY --from=build-aot /app/function/target/classes/*.properties /home/app/bin/config/
+COPY --from=build-aot /app/function/target/*-runner /home/app/bin/function
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 
 ENV cgi_headers="true"
-ENV fprocess="/home/app/function"
+ENV fprocess="function"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:8000"
 

--- a/template/quarkus-native/function/pom.xml
+++ b/template/quarkus-native/function/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus.version>1.2.0.Final</quarkus.version>
+    <quarkus.version>1.9.2.Final</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
- Update **quarkus** from **1.2.0.Final** to **1.9.2.Final**
- Update **graalvm** build container from **19.3.1-java11**  to **20.3.0-java11**
- Update Openfaas **of-watchdog** from **0.7.6** to **0.8.1**
- Copy **application.properties** to config dir with quarkus executable
- Move **function** dir to **/home/app/** to load properties from config/ dir (no slim)

Function usage example: https://github.com/zodo-dev/openfaas-functions-samples